### PR TITLE
Manifest fixes: Add geopy dependency & version key

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,11 @@
 {
   "domain": "fmi",
+  "version": "0.3.0",
   "name": "Finnish Meteorological Institute",
   "documentation": "https://www.home-assistant.io/integrations/fmi/",
   "requirements": [
-    "fmi-weather-client==0.1.1"
+    "fmi-weather-client==0.1.1",
+    "geopy>=2.1.0"
   ],
   "dependencies": [],
   "codeowners": [


### PR DESCRIPTION
* The version key is required by new versions of HA (fixes #17)
* Geopy is a required dependency (https://community.home-assistant.io/t/custom-fmi-finnish-meteorological-institute-weather-sensor-platform/186839/15)