### PR TITLE
Fixes warning logged during Home Assistant start

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -68,18 +68,17 @@ async def async_setup_entry(hass, config_entry) -> bool:
         UNDO_UPDATE_LISTENER: undo_listener,
     }
 
-    for component in PLATFORMS:
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(config_entry, component)
-        )
+    await hass.config_entries.async_forward_entry_setups(
+        config_entry,
+        PLATFORMS
+    )
 
     return True
 
 
 async def async_unload_entry(hass, config_entry):
     """Unload an FMI config entry."""
-    for component in PLATFORMS:
-        await hass.config_entries.async_forward_entry_unload(config_entry, component)
+    await hass.config_entries.async_unload_platforms(config_entry, PLATFORMS)
 
     hass.data[DOMAIN][config_entry.entry_id][UNDO_UPDATE_LISTENER]()
     hass.data[DOMAIN].pop(config_entry.entry_id)


### PR DESCRIPTION
See https://developers.home-assistant.io/blog/2024/06/12/async_forward_entry_setups/ for more information.

Fixes warnings like this:

```
2024-06-18 20:06:22.690 WARNING (MainThread) [homeassistant.helpers.frame] Detected that custom integration 'fmi' calls async_forward_entry_setup for integration, fmi with title: Bodö and entry_id: 2bd0b11d9f9c95f134faab9e4ddb03e8, which is deprecated and will stop working in Home Assistant 2025.6, await async_forward_entry_setups instead at custom_components/fmi/__init__.py, line 72: hass.async_create_task(, please report it to the author of the 'fmi' custom integration
```