### PR TITLE
Fix HA 2024.11 warning

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -12,7 +12,8 @@ from fmi_weather_client.errors import ClientError, ServerError
 from geopy.distance import geodesic
 from geopy.geocoders import Nominatim
 from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, CONF_OFFSET
-from homeassistant.core import Config, HomeAssistant
+from homeassistant.core import HomeAssistant
+from homeassistant.core_config import Config
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import (DataUpdateCoordinator,

--- a/__init__.py
+++ b/__init__.py
@@ -13,7 +13,12 @@ from geopy.distance import geodesic
 from geopy.geocoders import Nominatim
 from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, CONF_OFFSET
 from homeassistant.core import HomeAssistant
-from homeassistant.core_config import Config
+try:
+    # HA 2024.11 and newer
+    from homeassistant.core_config import Config
+except ImportError:
+    # HA 2024.10 and older
+    from homeassistant.core import Config
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import (DataUpdateCoordinator,


### PR DESCRIPTION
After updating to 2024.11, I got this warning during startup:

```
Config was used from fmi, this is a deprecated alias which will be removed in HA Core 2025.11. Use homeassistant.core_config.Config instead, please report it to the author of the 'fmi' custom integration
```