### PR TITLE
Fix unit for wind speed in forecasts.

### DIFF
--- a/weather.py
+++ b/weather.py
@@ -214,7 +214,7 @@ class FMIWeatherEntity(CoordinatorEntity, WeatherEntity):
                             ATTR_FORECAST_NATIVE_TEMP: forecast.temperature.value,
                             ATTR_FORECAST_NATIVE_TEMP_LOW: forecast.temperature.value,
                             ATTR_FORECAST_NATIVE_PRECIPITATION: forecast.precipitation_amount.value,
-                            ATTR_FORECAST_NATIVE_WIND_SPEED: forecast.wind_speed.value,
+                            ATTR_FORECAST_NATIVE_WIND_SPEED: forecast.wind_speed.value * 3.6,  # Convert m/s to km/h
                             ATTR_FORECAST_WIND_BEARING: forecast.wind_direction.value,
                             ATTR_WEATHER_PRESSURE: forecast.pressure.value,
                             ATTR_WEATHER_HUMIDITY: forecast.humidity.value,
@@ -237,7 +237,7 @@ class FMIWeatherEntity(CoordinatorEntity, WeatherEntity):
                         ),
                         ATTR_FORECAST_NATIVE_TEMP: forecast.temperature.value,
                         ATTR_FORECAST_NATIVE_PRECIPITATION: forecast.precipitation_amount.value,
-                        ATTR_FORECAST_NATIVE_WIND_SPEED: forecast.wind_speed.value,
+                        ATTR_FORECAST_NATIVE_WIND_SPEED: forecast.wind_speed.value * 3.6,  # Convert m/s to km/h
                         ATTR_FORECAST_WIND_BEARING: forecast.wind_direction.value,
                         ATTR_WEATHER_PRESSURE: forecast.pressure.value,
                         ATTR_WEATHER_HUMIDITY: forecast.humidity.value,


### PR DESCRIPTION
The fmi-weather-client lib provides wind speeds in m/s while HA expects km/h. This is an attempt to fix the units for weather forecasts.