### PR TITLE
Move observation data to its own weather sensor.

### DIFF
--- a/config_flow.py
+++ b/config_flow.py
@@ -177,9 +177,8 @@ class FMIOptionsFlowHandler(config_entries.OptionsFlow):
                              default=_options.get(
                                  const.CONF_LIGHTNING_DISTANCE,
                                  const.BOUNDING_BOX_HALF_SIDE_KM)): cv.positive_int,
-                vol.Optional(const.CONF_OBSERVATION_EN,
+                vol.Optional(const.CONF_OBSERVATION_STATION,
                              default=_options.get(
-                                 const.CONF_OBSERVATION_EN,
-                                 const.OBSERVATION_DEFAULT)): cv.boolean,
+                                 const.CONF_OBSERVATION_STATION, 0)): cv.positive_int,
             })
         )

--- a/const.py
+++ b/const.py
@@ -15,7 +15,9 @@ TIMEOUT_MAREO_PULL_IN_SECS = 5
 LIGHTNING_LOOP_TIMEOUT_IN_SECS = 20
 
 COORDINATOR = "coordinator"
-MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=30)
+COORDINATOR_OBSERVATION = "coordinator_observation"
+FORECAST_UPDATE_INTERVAL = timedelta(minutes=30)
+OBSERVATION_UPDATE_INTERVAL = timedelta(minutes=10)
 UNDO_UPDATE_LISTENER = "undo_update_listener"
 
 CONF_FORECAST_DAYS = "forecast_days"

--- a/const.py
+++ b/const.py
@@ -30,7 +30,7 @@ CONF_MAX_PRECIPITATION = "max_precipitation"
 CONF_DAILY_MODE = "daily_mode"
 CONF_LIGHTNING = "lightning_sensor"
 CONF_LIGHTNING_DISTANCE = "lightning_radius"
-CONF_OBSERVATION_EN = "observation_enabled"
+CONF_OBSERVATION_STATION = "observation_station_id"
 
 HUMIDITY_RANGE = list(range(1, 101))
 HUMIDITY_MIN_DEFAULT = 30
@@ -47,7 +47,6 @@ PRECIPITATION_MIN_DEFAULT = .0
 PRECIPITATION_MAX_DEFAULT = .2
 DAILY_MODE_DEFAULT = False
 LIGHTNING_DEFAULT = False
-OBSERVATION_DEFAULT = True
 
 FORECAST_OFFSET = [1, 2, 3, 4, 6, 8, 12, 24]  # Based on API test runs
 DEFAULT_NAME = "FMI"

--- a/translations/en.json
+++ b/translations/en.json
@@ -36,7 +36,7 @@
                     "daily_mode": "Activate Daily forecast entity",
                     "lightning_sensor": "Activate Lightning sensor",
                     "lightning_radius": "Lightning sensor radius km",
-                    "observation_enabled": "Enable Observation"
+                    "observation_station_id": "FMI's Observation Station ID"
                 },
                 "description": "Maximum and minimum parameters are used to determine the Best Time Of The Day",
                 "title": "Finnish Meteorological Institute Options"

--- a/translations/fi.json
+++ b/translations/fi.json
@@ -36,7 +36,7 @@
                     "daily_mode": "Aktivoi vuorokausiennuste-entiteetti",
                     "lightning_sensor": "Aktivoi ukkostutka",
                     "lightning_radius": "Ukkostutkan säde km",
-                    "observation_enabled": "Ota havainnot käyttöön"
+                    "observation_station_id": "FMI:n havaintoaseman ID"
                 },
                 "description": "Maksimin ja minimin sisältävät parametrit käytetään määrittämään päivän parhaan ajan",
                 "title": "Ilmatieteen laitos asetukset"


### PR DESCRIPTION
Also change observation station id to user modifiable. Otherwise this seems to be a bit too broad and could fetch data from wrong station. Fixes #104.
FMI's observation station ID (`FMISID`) can be found from [this](https://www.ilmatieteenlaitos.fi/havaintoasemat) list.

Observation sensor will also fix #100 and fix #103.

Also add a own update coordinator for observation data. This will configure independent update intervals for forecast (30min) and observation (10min). Resolves #99.